### PR TITLE
Check if plugins_loaded has happened before initializing

### DIFF
--- a/lazyload-liveblog-entries.php
+++ b/lazyload-liveblog-entries.php
@@ -90,19 +90,6 @@ class Liveblog_Lazyloader {
 
 }
 
-function liveblog_lazyloader_init() {
-	global $liveblog_lazyloader;
-	$liveblog_lazyloader = new Liveblog_Lazyloader();
-}
+global $liveblog_lazyloader;
 
-/*
- * Allow this to work if required in a theme rather than being loaded with plugins.
- *
- * (The priority: 1000 is there to make sure this loads after liveblog, which is initialized at priority 999.)
- */
-if ( did_action( 'plugins_loaded' ) ) {
-	liveblog_lazyloader_init();
-} else {
-	add_action( 'plugins_loaded', 'liveblog_lazyloader_init', 1000 );
-}
-
+$liveblog_lazyloader = new Liveblog_Lazyloader();

--- a/lazyload-liveblog-entries.php
+++ b/lazyload-liveblog-entries.php
@@ -95,5 +95,14 @@ function liveblog_lazyloader_init() {
 	$liveblog_lazyloader = new Liveblog_Lazyloader();
 }
 
-add_action( 'plugins_loaded', 'liveblog_lazyloader_init', 1000 );
+/*
+ * Allow this to work if required in a theme rather than being loaded with plugins.
+ *
+ * (The priority: 1000 is there to make sure this loads after liveblog, which is initialized at priority 999.)
+ */
+if ( did_action( 'plugins_loaded' ) ) {
+	liveblog_lazyloader_init();
+} else {
+	add_action( 'plugins_loaded', 'liveblog_lazyloader_init', 1000 );
+}
 


### PR DESCRIPTION
This step is required for the plugin to work when required() as part of a VIP theme. (there's probably a better way to do this...)